### PR TITLE
Add CurrentJumpingControllerBoundary cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -4,3 +4,10 @@
 #   Description: 'TODO: Write a description of the cop.'
 #   Enabled: pending
 #   VersionAdded: '0.80'
+
+Bugcrowd/CurrentJumpingControllerBoundary:
+  Description: 'Catches Current jumping controller boundaries'
+  Enabled: true
+  Exclude:
+    - 'spec/**/*.rb'
+    - 'app/controllers/**/*.rb'

--- a/lib/rubocop/cop/bugcrowd/current_jumping_controller_boundary.rb
+++ b/lib/rubocop/cop/bugcrowd/current_jumping_controller_boundary.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# TODO: when finished, run `rake generate_cops_documentation` to update the docs
+module RuboCop
+  module Cop
+    module Bugcrowd
+      # @example EnforcedStyle: bar (default)
+      #   # Description of the `bar` style.
+      #
+      #   # bad
+      #   Current.thingo
+      #
+      #   # good
+      #   Command.call(thing: Current.thingo)
+      #
+      class CurrentJumpingControllerBoundary < Cop
+        MSG = 'Curent should not be used outside of controllers. '\
+              'Pass it along to other systems that need it'
+
+        def_node_matcher :current_called?, <<~PATTERN
+          (send (const nil? :Current) _ ...)
+        PATTERN
+
+        def on_send(node)
+          return unless current_called?(node)
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/bugcrowd_cops.rb
+++ b/lib/rubocop/cop/bugcrowd_cops.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'bugcrowd/current_jumping_controller_boundary'
 require_relative 'bugcrowd/database'
 require_relative 'bugcrowd/faker'
 

--- a/spec/rubocop/cop/bugcrowd/current_jumping_controller_boundary_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/current_jumping_controller_boundary_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Bugcrowd::CurrentJumpingControllerBoundary do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when using Current' do
+    expect_offense(<<~RUBY)
+      Current.baz.bar
+      ^^^^^^^^^^^ Curent should not be used outside of controllers. Pass it along to other systems that need it
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/bugcrowd/current_jumping_controller_boundary_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/current_jumping_controller_boundary_spec.rb
@@ -11,4 +11,10 @@ RSpec.describe RuboCop::Cop::Bugcrowd::CurrentJumpingControllerBoundary do
       ^^^^^^^^^^^ Curent should not be used outside of controllers. Pass it along to other systems that need it
     RUBY
   end
+
+  it 'does not register an offense for unrelated const' do
+    expect_no_offenses(<<~RUBY)
+      Flurrent.baz.bar
+    RUBY
+  end
 end


### PR DESCRIPTION
`ActiveSupport::CurrentAttributes` should not jump the controller boundary as it introduces global state where it can be easily injected instead. Think of `Current` as an alternative to magic methods like `current_blah_blah` injected into every controller _instead of_ an easy way of easily grabbing global state no matter where you are.