### PR TITLE
Add DisableDdlOnlyWithNonDdlStatements cop

### DIFF
--- a/lib/rubocop/cop/bugcrowd/add_index_non_concurrently.rb
+++ b/lib/rubocop/cop/bugcrowd/add_index_non_concurrently.rb
@@ -27,18 +27,10 @@ module RuboCop
           (send nil? :add_index ...)
         PATTERN
 
-        def_node_matcher :add_index_with_concurrent?, <<~PATTERN
-          (send nil? :add_index _ _
-            (hash
-              <(pair (sym :algorithm) (sym :concurrently)) ...>
-            )
-          )
-        PATTERN
-
         def on_send(node)
           within_change_or_up_method?(node) &&
             add_index?(node) &&
-            !add_index_with_concurrent?(node) &&
+            !add_index_concurrently?(node) &&
             add_offense(node)
         end
       end

--- a/lib/rubocop/cop/bugcrowd/database.rb
+++ b/lib/rubocop/cop/bugcrowd/database.rb
@@ -28,6 +28,26 @@ module RuboCop
             )
           )
         PATTERN
+
+        def_node_matcher :add_index_concurrently?, <<~PATTERN
+          (send nil? :add_index _ _
+            (hash
+              <(pair (sym :algorithm) (sym :concurrently)) ...>
+            )
+          )
+        PATTERN
+
+        def_node_matcher :ddl_method?, <<~PATTERN
+          {:create_join_table :create_table :add_column :add_foreign_key :add_reference :add_timestamps :change_column :change_column_default :change_column_null :change_table :rename_column :rename_index :rename_table :drop_table :drop_join_table :remove_column :remove_columns :remove_foreign_key :remove_index :remove_index :remove_reference :remove_timestamps}
+        PATTERN
+
+        def_node_matcher :ddl_statement?, <<~PATTERN
+          (send nil? #ddl_method? ...)
+        PATTERN
+
+        def_node_search :with_disable_ddl_transaction_set?, <<~PATTERN
+          (send nil? :disable_ddl_transaction!)
+        PATTERN
       end
     end
   end

--- a/lib/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements.rb
+++ b/lib/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements.rb
@@ -38,7 +38,7 @@ module RuboCop
         def on_send(node)
           within_change_or_up_method?(node) &&
             ddl_statement?(node) &&
-            with_disable_ddl_transaction_set?(node.parent.parent) &&
+            node.ancestors.any?(&method(:with_disable_ddl_transaction_set?)) &&
             add_offense(node)
         end
       end

--- a/lib/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements.rb
+++ b/lib/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements.rb
@@ -21,28 +21,6 @@ module RuboCop
 
         MSG = 'Only disable ddl transactions for non-ddl statements'
 
-        # add_index
-
-        def_node_matcher :ddl_method?, <<~PATTERN
-          {:create_join_table :create_table :add_column :add_foreign_key :add_reference :add_timestamps :change_column :change_column_default :change_column_null :change_table :rename_column :rename_index :rename_table :drop_table :drop_join_table :remove_column :remove_columns :remove_foreign_key :remove_index :remove_index :remove_reference :remove_timestamps}
-        PATTERN
-
-        def_node_matcher :ddl_statement?, <<~PATTERN
-          (send nil? #ddl_method? ...)
-        PATTERN
-
-        def_node_search :with_disable_ddl_transaction_set?, <<~PATTERN
-          (send nil? :disable_ddl_transaction!)
-        PATTERN
-
-        def_node_matcher :add_index_with_concurrent?, <<~PATTERN
-          (send nil? :add_index _ _
-            (hash
-              <(pair (sym :algorithm) (sym :concurrently)) ...>
-            )
-          )
-        PATTERN
-
         def_node_matcher :add_index?, <<~PATTERN
           (send nil? :add_index ...)
         PATTERN
@@ -55,7 +33,7 @@ module RuboCop
         end
 
         def add_index_without_concurrently?(node)
-          add_index?(node) && !add_index_with_concurrent?(node)
+          add_index?(node) && !add_index_concurrently?(node)
         end
       end
     end

--- a/lib/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements.rb
+++ b/lib/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Bugcrowd
+      #   See https://thoughtbot.com/blog/how-to-create-postgres-indexes-concurrently-in
+      #
+      #   # bad
+      #   add_index :table_name, [:derp, :dap], unique: true, algorithm: :flunflurrently
+      #
+      #   # bad
+      #   add_index :table_name, :column_name, unique: true
+      #
+      #   # good
+      #   add_index :table_name, [:derp, :dap], unique: true, algorithm: :concurrently
+      #
+      #   # good
+      #   add_index :table_name, :column, zibble: :bibble, algorithm: :concurrently
+      class DisableDdlOnlyWithNonDdlStatements < Cop
+        include Database
+
+        MSG = 'Only disable ddl transactions for non-ddl statements'
+
+        # add_index
+
+        def_node_matcher :ddl_method?, <<~PATTERN
+          {:create_join_table :create_table :add_column :add_foreign_key :add_reference :add_timestamps :change_column :change_column_default :change_column_null :change_table :rename_column :rename_index :rename_table :drop_table :drop_join_table :remove_column :remove_columns :remove_foreign_key :remove_index :remove_index :remove_reference :remove_timestamps}
+        PATTERN
+
+        def_node_matcher :ddl_statement?, <<~PATTERN
+          (send nil? #ddl_method? ...)
+        PATTERN
+
+        def_node_matcher :with_disable_ddl_transaction_set?, <<~PATTERN
+          (send nil? :create_table ...)
+        PATTERN
+
+
+        def on_send(node)
+          binding.pry
+          if within_change_or_up_method?(node) 
+            binding.pry
+            if ddl_statement?(node)
+              binding.pry
+              if with_disable_ddl_transaction_set?(node)
+                add_offense(node)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements.rb
+++ b/lib/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements.rb
@@ -31,22 +31,15 @@ module RuboCop
           (send nil? #ddl_method? ...)
         PATTERN
 
-        def_node_matcher :with_disable_ddl_transaction_set?, <<~PATTERN
-          (send nil? :create_table ...)
+        def_node_search :with_disable_ddl_transaction_set?, <<~PATTERN
+          (send nil? :disable_ddl_transaction!)
         PATTERN
 
-
         def on_send(node)
-          binding.pry
-          if within_change_or_up_method?(node) 
-            binding.pry
-            if ddl_statement?(node)
-              binding.pry
-              if with_disable_ddl_transaction_set?(node)
-                add_offense(node)
-              end
-            end
-          end
+          within_change_or_up_method?(node) &&
+            ddl_statement?(node) &&
+            with_disable_ddl_transaction_set?(node.parent.parent) &&
+            add_offense(node)
         end
       end
     end

--- a/lib/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements.rb
+++ b/lib/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements.rb
@@ -3,19 +3,22 @@
 module RuboCop
   module Cop
     module Bugcrowd
-      #   See https://thoughtbot.com/blog/how-to-create-postgres-indexes-concurrently-in
-      #
       #   # bad
-      #   add_index :table_name, [:derp, :dap], unique: true, algorithm: :flunflurrently
+      #   class DerpMigration < ActiveRecord::Migration[5.2]
+      #     disable_ddl_transaction!
       #
-      #   # bad
-      #   add_index :table_name, :column_name, unique: true
+      #     def change
+      #       add_column(:table_name, :offensive_name)
+      #     end
+      #   end
       #
       #   # good
-      #   add_index :table_name, [:derp, :dap], unique: true, algorithm: :concurrently
-      #
-      #   # good
-      #   add_index :table_name, :column, zibble: :bibble, algorithm: :concurrently
+      #   class DerpMigration < ActiveRecord::Migration[5.2]
+      #     disable_ddl_transaction!
+      #     def change
+      #       add_index :table_name, :column_name, unique: true, algorithm: :concurrently
+      #     end
+      #   end
       class DisableDdlOnlyWithNonDdlStatements < Cop
         include Database
 

--- a/lib/rubocop/cop/bugcrowd_cops.rb
+++ b/lib/rubocop/cop/bugcrowd_cops.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 require_relative 'bugcrowd/dangerous_env_mutation'
-require_relative 'bugcrowd/database'
 require_relative 'bugcrowd/faker'
 
+require_relative 'bugcrowd/database'
+require_relative 'bugcrowd/disable_ddl_only_with_non_ddl_statements'
 require_relative 'bugcrowd/prefer_text_to_string_column'
 require_relative 'bugcrowd/uuid_primary_keys'
 require_relative 'bugcrowd/no_commit_db_transaction'

--- a/spec/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Bugcrowd::DisableDdlOnlyWithNonDdlStatements do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  # TODO: Write test code
+  #
+
+        # create_table(:table_name, :column_name)
+        # add_column(:table_name, :column_name)
+        # add_foreign_key(:table_name, :column_name)
+        # add_index(:table_name, :column_name)
+        # add_reference(:table_name, :column_name)
+        # add_timestamps(:table_name, :column_name)
+        # change_column(:table_name, :column_name)
+        # change_column_default(:table_name, :column_name)
+        # change_column_null(:table_name, :column_name)
+        # change_table(:table_name, :column_name)
+        # rename_column(:table_name, :column_name)
+        # rename_index(:table_name, :column_name)
+        # rename_table(:table_name, :column_name)
+        # drop_table(:table_name, :column_name)
+        # drop_join_table(:table_name, :column_name)
+        # remove_column(:table_name, :column_name)
+        # remove_columns(:table_name, :column_name)
+        # remove_foreign_key(:table_name, :column_name)
+        # remove_index(:table_name, :column_name)
+        # remove_index(:table_name, :column_name)
+        # remove_reference(:table_name, :column_name)
+        # remove_timestamps(:table_name, :column_name)
+  # For example
+  it 'registers an offense when using `#bad_method`' do
+    expect_offense(<<~RUBY)
+      add_index :table_name, [:derp, :dap], unique: true, algorithm: :flunflurrently
+    RUBY
+  end
+
+  xit 'does not register an offense when using `#good_method`' do
+    expect_no_offenses(<<~RUBY)
+      good_method
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements_spec.rb
@@ -41,6 +41,34 @@ RSpec.describe RuboCop::Cop::Bugcrowd::DisableDdlOnlyWithNonDdlStatements do
     RUBY
   end
 
+  it 'registers an offense when adding a column with disable_ddl_transaction!' do
+    expect_offense(<<~RUBY)
+      class DerpMigration < ActiveRecord::Migration[5.2]
+        disable_ddl_transaction!
+
+        def up
+          add_column(:table_name, :offensive_name)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Only disable ddl transactions for non-ddl statements
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense deeply within ancestors' do
+    expect_offense(<<~RUBY)
+      class DerpMigration < ActiveRecord::Migration[5.2]
+        disable_ddl_transaction!
+
+        def up
+          4.times do |x|
+            add_column(:table_name, :offensive_name)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Only disable ddl transactions for non-ddl statements
+          end
+        end
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using the directive with a non-ddl command' do
     expect_no_offenses(<<~RUBY)
       class DerpMigration < ActiveRecord::Migration[5.2]

--- a/spec/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements_spec.rb
@@ -5,41 +5,61 @@ RSpec.describe RuboCop::Cop::Bugcrowd::DisableDdlOnlyWithNonDdlStatements do
 
   let(:config) { RuboCop::Config.new }
 
-  # TODO: Write test code
-  #
-
-        # create_table(:table_name, :column_name)
-        # add_column(:table_name, :column_name)
-        # add_foreign_key(:table_name, :column_name)
-        # add_index(:table_name, :column_name)
-        # add_reference(:table_name, :column_name)
-        # add_timestamps(:table_name, :column_name)
-        # change_column(:table_name, :column_name)
-        # change_column_default(:table_name, :column_name)
-        # change_column_null(:table_name, :column_name)
-        # change_table(:table_name, :column_name)
-        # rename_column(:table_name, :column_name)
-        # rename_index(:table_name, :column_name)
-        # rename_table(:table_name, :column_name)
-        # drop_table(:table_name, :column_name)
-        # drop_join_table(:table_name, :column_name)
-        # remove_column(:table_name, :column_name)
-        # remove_columns(:table_name, :column_name)
-        # remove_foreign_key(:table_name, :column_name)
-        # remove_index(:table_name, :column_name)
-        # remove_index(:table_name, :column_name)
-        # remove_reference(:table_name, :column_name)
-        # remove_timestamps(:table_name, :column_name)
+  # create_table(:table_name, :column_name)
+  # add_column(:table_name, :column_name)
+  # add_foreign_key(:table_name, :column_name)
+  # add_index(:table_name, :column_name)
+  # add_reference(:table_name, :column_name)
+  # add_timestamps(:table_name, :column_name)
+  # change_column(:table_name, :column_name)
+  # change_column_default(:table_name, :column_name)
+  # change_column_null(:table_name, :column_name)
+  # change_table(:table_name, :column_name)
+  # rename_column(:table_name, :column_name)
+  # rename_index(:table_name, :column_name)
+  # rename_table(:table_name, :column_name)
+  # drop_table(:table_name, :column_name)
+  # drop_join_table(:table_name, :column_name)
+  # remove_column(:table_name, :column_name)
+  # remove_columns(:table_name, :column_name)
+  # remove_foreign_key(:table_name, :column_name)
+  # remove_index(:table_name, :column_name)
+  # remove_index(:table_name, :column_name)
+  # remove_reference(:table_name, :column_name)
+  # remove_timestamps(:table_name, :column_name)
   # For example
-  it 'registers an offense when using `#bad_method`' do
+  it 'registers an offense when adding a column with disable_ddl_transaction!' do
     expect_offense(<<~RUBY)
-      add_index :table_name, [:derp, :dap], unique: true, algorithm: :flunflurrently
+      class DerpMigration < ActiveRecord::Migration[5.2]
+        disable_ddl_transaction!
+
+        def change
+          add_column(:table_name, :offensive_name)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Only disable ddl transactions for non-ddl statements
+        end
+      end
     RUBY
   end
 
-  xit 'does not register an offense when using `#good_method`' do
+  it 'does not register an offense when using the directive with a non-ddl command' do
     expect_no_offenses(<<~RUBY)
-      good_method
+      class DerpMigration < ActiveRecord::Migration[5.2]
+        disable_ddl_transaction!
+
+        def change
+          add_index :table_name, :column_name, unique: true, algorithm: :concurrently
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when not using the directive' do
+    expect_no_offenses(<<~RUBY)
+      class DerpMigration < ActiveRecord::Migration[5.2]
+        def change
+          add_column(:table_name, :column_name)
+        end
+      end
     RUBY
   end
 end


### PR DESCRIPTION
A somewhat naive approach to restricting use of `disable_ddl_transaction!` on ddl statements like `create_table` etc. You absolutely want to run those kinds of statements in a transaction so that they can run atomically. One notable (and often used) exception to that rule is adding concurrent indexes with Postgres. Non-concurrent indexes can take a long time and will b