### PR TITLE
Require belongs_to 'optional' kwarg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# txt editor files
+/.tool-versions

--- a/config/default.yml
+++ b/config/default.yml
@@ -33,3 +33,9 @@ Bugcrowd/RailsConfigurationMutation:
   Exclude:
     - 'spec/spec_helper.rb'
   Enabled: true
+
+Bugcrowd/RequireOptionalForBelongsTo:
+  Description: 'blah'
+  Include:
+    - 'app/models/**/*.rb'
+  Enabled: true

--- a/lib/rubocop/cop/bugcrowd/require_optional_for_belongs_to.rb
+++ b/lib/rubocop/cop/bugcrowd/require_optional_for_belongs_to.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Bugcrowd
+      class RequireOptionalForBelongsTo < RuboCop::Cop::Cop
+        # Ensures that the :optional argument is supplied to the belongs_to method
+        # to help with upgrading to the new rails default
+        #
+        # @example
+        #
+        # # bad
+        # ```
+        # class MyModel
+        #   belongs_to :other_model
+        # end
+        # ```
+        #
+        # # bad
+        # ```
+        # class MyModel
+        #   belongs_to :other_model, optional: nil
+        # end
+        # ```
+        #
+        # # good
+        # ```
+        # class MyModel
+        #   belongs_to :other_model, optional: true
+        # end
+        # ```
+        #
+        # # good
+        # ```
+        # class MyModel
+        #   belongs_to :other_model, optional: false
+        # end
+        # ```
+        #
+        MSG = 'Always specify whether belongs_to is optional using `optional: true/false`'
+
+        def_node_matcher :belongs_to_with_optional?, <<-PATTERN
+          (send nil? :belongs_to _+
+            (hash
+              <(pair (sym :optional) (!nil)) ...>
+            )
+          )
+        PATTERN
+
+        def_node_matcher :in_belongs_to?, <<-PATTERN
+          (send nil? :belongs_to ...)
+        PATTERN
+
+        def on_send(node)
+          if in_belongs_to?(node) && !belongs_to_with_optional?(node)
+            add_offense(node)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/bugcrowd_cops.rb
+++ b/lib/rubocop/cop/bugcrowd_cops.rb
@@ -23,3 +23,5 @@ require_relative 'bugcrowd/can_with_class_const'
 require_relative 'bugcrowd/controller_specs'
 require_relative 'bugcrowd/flipper_in_app_code'
 require_relative 'bugcrowd/travel_to_block_form'
+
+require_relative 'bugcrowd/require_optional_for_belongs_to'

--- a/spec/rubocop/cop/bugcrowd/require_optional_for_belongs_to_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/require_optional_for_belongs_to_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Bugcrowd::RequireOptionalForBelongsTo do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  context 'when optional is false' do
+    it 'does not register an offence' do
+      expect_no_offenses(<<~RUBY)
+        class MyModel
+          belongs_to :other_model, optional: false
+        end
+      RUBY
+    end
+  end
+
+  context 'when optional is true' do
+    it 'does not register an offence' do
+      expect_no_offenses(<<~RUBY)
+        class MyModel
+          belongs_to :other_model, optional: true
+        end
+      RUBY
+    end
+  end
+
+  context 'when belongs_to has many arguments' do
+    it 'does not register an offence' do
+      expect_no_offenses(<<~RUBY)
+        class MyModel
+          belongs_to :other_model, ->{ all }, class_name: 'Blah', optional: true, polymorphic: true
+        end
+      RUBY
+    end
+  end
+
+  context 'when optional is not passed' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class MyModel
+          belongs_to :other_model
+          ^^^^^^^^^^^^^^^^^^^^^^^ Always specify whether belongs_to is optional using `optional: true/false`
+        end
+      RUBY
+    end
+  end
+
+  context 'when optional is not passed with many arguments' do
+    it 'registers an offence' do
+      expect_offense(<<~RUBY)
+        class MyModel
+          belongs_to :other_model, ->{ all }, class_name: 'Blah', polymorphic: true
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Always specify whether belongs_to is optional using `optional: true/false`
+        end
+      RUBY
+    end
+  end
+
+  context 'when optional is passed as nill' do
+    it 'registers an offence' do
+      expect_offense(<<~RUBY)
+        class MyModel
+          belongs_to :other_model, ->{ all }, class_name: 'Blah', polymorphic: true
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Always specify whether belongs_to is optional using `optional: true/false`
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
We want to update our config to match the new rails default value for belongs_to:optional.

In order to assist with that migration, we want to require that all newly defined relationships have the optional key set to either true or false.