### PR TITLE
Add Bugcrowd/BuildStrategiesInFeatureRequestSpecs cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -5,6 +5,14 @@
 #   Enabled: pending
 #   VersionAdded: '0.80'
 
+Bugcrowd/BuildStrategiesInFeatureRequestSpecs:
+  Description: Avoid using build/build_stubed in feature/request specs
+  Enabled: true
+  Include:
+    - 'spec/features/**/*.rb'
+    - 'spec/requests/**/*.rb'
+    - 'spec/system/**/*.rb'
+
 Bugcrowd/CurrentJumpingControllerBoundary:
   Description: 'Catches Current jumping controller boundaries'
   Enabled: true

--- a/lib/rubocop/cop/bugcrowd/build_strategies_in_feature_request_specs.rb
+++ b/lib/rubocop/cop/bugcrowd/build_strategies_in_feature_request_specs.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# TODO: when finished, run `rake generate_cops_documentation` to update the docs
+module RuboCop
+  module Cop
+    module Bugcrowd
+      # TODO: Write cop description and example of bad / good code. For every
+      # `SupportedStyle` and unique configuration, there needs to be examples.
+      # Examples must have valid Ruby syntax. Do not use upticks.
+      #
+      # @example EnforcedStyle: bar (default)
+      #   # Description of the `bar` style.
+      #
+      #   # bad
+      #   bad_bar_method
+      #
+      #   # bad
+      #   bad_bar_method(args)
+      #
+      #   # good
+      #   good_bar_method
+      #
+      #   # good
+      #   good_bar_method(args)
+      #
+      # @example EnforcedStyle: foo
+      #   # Description of the `foo` style.
+      #
+      #   # bad
+      #   bad_foo_method
+      #
+      #   # bad
+      #   bad_foo_method(args)
+      #
+      #   # good
+      #   good_foo_method
+      #
+      #   # good
+      #   good_foo_method(args)
+      #
+      class BuildStrategiesInFeatureRequestSpecs < Cop
+        # TODO: Implement the cop in here.
+        #
+        # In many cases, you can use a node matcher for matching node pattern.
+        # See https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/node_pattern.rb
+        #
+        # For example
+        MSG = "Prefer 'create' in request/feature specs"
+
+        def_node_matcher :build_stubbed?, <<~PATTERN
+          (send nil? :build_stubbed ...)
+        PATTERN
+
+        def_node_matcher :build?, <<~PATTERN
+          (send nil? :build ...)
+        PATTERN
+
+        def on_send(node)
+          if build_stubbed?(node) || build?(node)
+            add_offense(node)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/bugcrowd_cops.rb
+++ b/lib/rubocop/cop/bugcrowd_cops.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'bugcrowd/build_strategies_in_feature_request_specs'
 require_relative 'bugcrowd/current_jumping_controller_boundary'
 require_relative 'bugcrowd/dangerous_env_mutation'
 require_relative 'bugcrowd/faker'

--- a/spec/rubocop/cop/bugcrowd/build_strategies_in_feature_request_specs_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/build_strategies_in_feature_request_specs_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Bugcrowd::BuildStrategiesInFeatureRequestSpecs do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  # TODO: Write test code
+  #
+  # For example
+  it 'registers an offense when using `#bad_method`' do
+    expect_offense(<<~RUBY)
+      build(:model_name, :thing, other: 'yay')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer 'create' in request/feature specs
+    RUBY
+  end
+
+  it 'registers an offense when using `#bad_method`' do
+    expect_offense(<<~RUBY)
+      build_stubbed(:model_name, :thing, other: 'yay')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer 'create' in request/feature specs
+    RUBY
+  end
+
+  it 'does not register an offense when using `#good_method`' do
+    expect_no_offenses(<<~RUBY)
+      create(:blah, :zah)
+    RUBY
+  end
+end


### PR DESCRIPTION
1. Request specs don't run in a separate thread, but the only stack context they receive is what you send through the HTTP request. You can setup stubs/mocks on constants and those will work, but it all becomes very tenuous.
1. Feature tests run in a completely separate thread. Mocks like `allow(Submission).to receive(:zibble).and_return :bibble` will work, but anything that involves the database will also be very tenuous.