### PR TITLE
Update auto-correcter to default to optional: false

### DIFF
--- a/lib/rubocop/cop/bugcrowd/require_optional_for_belongs_to.rb
+++ b/lib/rubocop/cop/bugcrowd/require_optional_for_belongs_to.rb
@@ -61,7 +61,7 @@ module RuboCop
           lambda do |corrector|
             corrector.replace(
               node.last_argument.loc.expression,
-              "#{node.last_argument.source}, optional: true"
+              "#{node.last_argument.source}, optional: false"
             )
           end
         end

--- a/spec/rubocop/cop/bugcrowd/require_optional_for_belongs_to_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/require_optional_for_belongs_to_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::Bugcrowd::RequireOptionalForBelongsTo do
       )
     ).to eq(
       'belongs_to :other_model, ->{ all }, ' \
-      "class_name: 'Blah', polymorphic: true, optional: true"
+      "class_name: 'Blah', polymorphic: true, optional: false"
     )
   end
 end


### PR DESCRIPTION
We made this default to true to make it easier for us to autocorrect in our repo. Now we've run it in our repo, switching the auotcorrect to do the better default.