### PR TITLE
Add rule to encourage transactionally safe event publishing

### DIFF
--- a/lib/rubocop/cop/bugcrowd/no_event_deprecated_publish.rb
+++ b/lib/rubocop/cop/bugcrowd/no_event_deprecated_publish.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Bugcrowd
+      class NoEventDeprecatedPublish < Cop
+        #   The way we publish events, we don't want to publish the event externally if the
+        #   transaction triggering it has been rolled back.  We also don't want the event to be
+        #   rolled back in the case that processing the event fails so we do not lose record of
+        #   the original event.  Instead of saving and publishing the event in the same call you
+        #   should save the new event first, then publish it.
+        #
+        #   # bad
+        #   ActiveRecord::Base.transaction do
+        #     new_record.save!
+        #     EventStore.deprecated_publish(resource: new_record, data: { blah: 'string' })
+        #   end
+        #
+        #   # good
+        #   ActiveRecord::Base.transaction do
+        #     new_record.save!
+        #     new_event = Event.create!(resource: new_record, data: { blah: 'string' })
+        #   end
+        #   new_event.publish!
+        #
+        MSG = 'Prefer the new form of saving the event first within the same transaction as ' \
+              'the data mutation, then calling `new_event.publish!` outside of the transaction.'
+
+        def_node_matcher :using_deprecated_publish?, <<~PATTERN
+          (send (const nil? :EventStore) :deprecated_publish ...)
+        PATTERN
+
+        def on_send(node)
+          add_offense(node) if using_deprecated_publish?(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/bugcrowd_cops.rb
+++ b/lib/rubocop/cop/bugcrowd_cops.rb
@@ -26,3 +26,4 @@ require_relative 'bugcrowd/travel_to_block_form'
 
 require_relative 'bugcrowd/require_optional_for_belongs_to'
 require_relative 'bugcrowd/no_unrestricted_polymorph'
+require_relative 'bugcrowd/no_event_deprecated_publish'

--- a/spec/rubocop/cop/bugcrowd/no_event_deprecated_publish_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/no_event_deprecated_publish_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Bugcrowd::NoEventDeprecatedPublish do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offence when calling deprecated_publish on EventStore' do
+    expect_offense(<<~RUBY)
+      EventStore.deprecated_publish(data: { blah: 'string' })
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer the new form of saving the event first within the same transaction as the data mutation, then calling `new_event.publish!` outside of the transaction.
+    RUBY
+  end
+
+  it 'does not register an offense when using the new form of publish' do
+    expect_no_offenses(<<~RUBY)
+      event = Event.create!(data: { blah: 'string' })
+      event.publish!
+    RUBY
+  end
+end


### PR DESCRIPTION
The way we publish events, we don't want to publish the event externally if the
transaction triggering it has been rolled back.  We also don't want the event to be
rolled back in the case that processing the event fails so we do not lose record of
the original event.  Instead of saving and publishing the event in the same call you
should save the new event first, then publish it.

### bad
```ruby
ActiveRecord::Base.transaction do
  new_record.save!
  EventStore.deprecated_publish(resource: new_record, data: { blah: 'string' })
end
```

### good
```ruby
ActiveRecord::Base.transaction do
  new_record.save!
  new_event = Event.create!(resource: new_record, data: { blah: 'string' })
end
new_event.publish!
```