### PR TITLE
Bugcrowd/AvoidSampleInSpecs

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -44,3 +44,9 @@ Bugcrowd/DangerousTransaction:
   Description: Prefer ProperTransaction.start to custom transactions
   Enabled: true
   VersionAdded: '0.80'
+
+Bugcrowd/AvoidSampleInSpecs:
+  Description: Avoid using sample in spec as it can cause non-deterministic behavior
+  Enabled: true
+  Include:
+    - 'spec/**/*.rb'

--- a/lib/rubocop/cop/bugcrowd/avoid_sample_in_specs.rb
+++ b/lib/rubocop/cop/bugcrowd/avoid_sample_in_specs.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# TODO: when finished, run `rake generate_cops_documentation` to update the docs
+module RuboCop
+  module Cop
+    module Bugcrowd
+      #
+      #   # bad
+      #   thing = list_of_things.sample
+      #   expect(thing).to have_some_property
+      #
+      #   # good
+      #   list_of_things.each do |thing|
+      #     expect(thing).to have_some_property
+      #   end
+      #
+      #   # good
+      #   expect(thing).to have_some_property
+      #   expect(thing1).to have_some_property
+      #
+      class AvoidSampleInSpecs < Cop
+        MSG = 'Avoid using sample in spec as it can cause non-deterministic behavior'
+
+        def_node_matcher :sample?, <<~PATTERN
+          (send ... :sample)
+        PATTERN
+
+        def on_send(node)
+          return unless sample?(node)
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/bugcrowd/avoid_sample_in_specs.rb
+++ b/lib/rubocop/cop/bugcrowd/avoid_sample_in_specs.rb
@@ -22,7 +22,7 @@ module RuboCop
         MSG = 'Avoid using sample in spec as it can cause non-deterministic behavior'
 
         def_node_matcher :sample?, <<~PATTERN
-          (send ... :sample)
+          (send _ :sample ...)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/bugcrowd_cops.rb
+++ b/lib/rubocop/cop/bugcrowd_cops.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'bugcrowd/avoid_sample_in_specs'
 require_relative 'bugcrowd/current_jumping_controller_boundary'
 require_relative 'bugcrowd/dangerous_env_mutation'
 require_relative 'bugcrowd/faker'

--- a/spec/rubocop/cop/bugcrowd/avoid_sample_in_specs_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/avoid_sample_in_specs_spec.rb
@@ -12,6 +12,20 @@ RSpec.describe RuboCop::Cop::Bugcrowd::AvoidSampleInSpecs do
     RUBY
   end
 
+  it 'registers an offense when using sample with single arg' do
+    expect_offense(<<~RUBY)
+      blah.zah.sample(3)
+      ^^^^^^^^^^^^^^^^^^ Avoid using sample in spec as it can cause non-deterministic behavior
+    RUBY
+  end
+
+  it 'registers an offense when using sample with random' do
+    expect_offense(<<~RUBY)
+      blah.zah.sample(3, random: 1)
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid using sample in spec as it can cause non-deterministic behavior
+    RUBY
+  end
+
   it 'does not register an offense when using a different method' do
     expect_no_offenses(<<~RUBY)
       blah.zah.not_sample

--- a/spec/rubocop/cop/bugcrowd/avoid_sample_in_specs_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/avoid_sample_in_specs_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Bugcrowd::AvoidSampleInSpecs do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when using sample' do
+    expect_offense(<<~RUBY)
+      blah.zah.sample
+      ^^^^^^^^^^^^^^^ Avoid using sample in spec as it can cause non-deterministic behavior
+    RUBY
+  end
+
+  it 'does not register an offense when using a different method' do
+    expect_no_offenses(<<~RUBY)
+      blah.zah.not_sample
+    RUBY
+  end
+end


### PR DESCRIPTION
https://bugcrowd.slack.com/archives/C3GJMP5U3/p1614847505002700

The use of `sample` in specs can cause the spec to pass on local machines but then fail randomly on CI due to `sample` relying on the Kernel.random value. In almost all cases, it is possible to achieve the same level of coverage without the non-determinism. This has been a problem in our codebase for a while, so good to finally close the book.