### PR TITLE
Bugcrowd/PreferSensibleStringEnum

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -26,6 +26,10 @@ Bugcrowd/DangerousEnvMutation:
     - 'spec/spec_helper.rb'
   Enabled: true
 
+Bugcrowd/PreferSensibleStringEnum:
+  Description: 'Prefer SensibleStringEnum over built in Rails enum'
+  Enabled: true
+
 Bugcrowd/RailsConfigurationMutation:
   Description: 'Prevent direct modification of Rails config to prevent global state pollution'
   Include:

--- a/lib/rubocop/cop/bugcrowd/prefer_sensible_string_enum.rb
+++ b/lib/rubocop/cop/bugcrowd/prefer_sensible_string_enum.rb
@@ -3,6 +3,12 @@
 module RuboCop
   module Cop
     module Bugcrowd
+      #  SensibleStringEnum has a number of advantages over the built in Rails enum.
+      #  1. Rails string enums are not supported very well. They are really meant for
+      #     traditional integer enums -- which I've never actually seen used.
+      #  2. Rails enums throw runtime exceptions when they are SET instead of at validation
+      #  3. Rails enums add a ton of methods to the class they are added to, many of which are
+      #     not very helpful
       #
       #   # bad
       #   enum source: { web: 'web', csv: 'csv' }

--- a/lib/rubocop/cop/bugcrowd/prefer_sensible_string_enum.rb
+++ b/lib/rubocop/cop/bugcrowd/prefer_sensible_string_enum.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Bugcrowd
+      #
+      #   # bad
+      #   enum source: { web: 'web', csv: 'csv' }
+      #
+      #   # good
+      #   include SensibleStringEnum
+      #
+      #   enumerate_strings_for :source, [:web, :csv]
+      #
+      class PreferSensibleStringEnum < Cop
+        MSG = 'Prefer SensibleStringEnum over built in Rails enum.'
+
+        def_node_matcher :enum?, <<~PATTERN
+          (send nil? :enum ...)
+        PATTERN
+
+        def on_send(node)
+          return unless enum?(node)
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/bugcrowd_cops.rb
+++ b/lib/rubocop/cop/bugcrowd_cops.rb
@@ -3,6 +3,7 @@
 require_relative 'bugcrowd/current_jumping_controller_boundary'
 require_relative 'bugcrowd/dangerous_env_mutation'
 require_relative 'bugcrowd/faker'
+require_relative 'bugcrowd/prefer_sensible_string_enum'
 require_relative 'bugcrowd/rails_configuration_mutation'
 
 require_relative 'bugcrowd/database'

--- a/spec/rubocop/cop/bugcrowd/prefer_sensible_string_enum_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/prefer_sensible_string_enum_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Bugcrowd::PreferSensibleStringEnum do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when using `#enum`' do
+    expect_offense(<<~RUBY)
+      enum species: { dog: 'dog' }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer SensibleStringEnum over built in Rails enum.
+    RUBY
+  end
+
+  it 'registers an offense when using `#enum` in multiline' do
+    expect_offense(<<~RUBY)
+      enum species: {
+      ^^^^^^^^^^^^^^^ Prefer SensibleStringEnum over built in Rails enum.
+        dog: 'dog'
+      }
+    RUBY
+  end
+
+  it 'does not register an offense when using `#enumerate_strings_for`' do
+    expect_no_offenses(<<~RUBY)
+      enumerate_strings_for :species, %i[dog cat bird], allow_nil: true
+    RUBY
+  end
+end


### PR DESCRIPTION
SensibleStringEnum has a number of advantages over the built in Rails enum.

1. Rails string enums are not supported very well. They are really meant for traditional integer enums -- which I've never actually seen used.
1. Rails enums throw runtime exceptions when they are SET instead of at validation
1. Rails enums add a _ton_ of methods to the class they are added to, many of which are not very helpful

Just a note that this doesn't introspect the enum to check if it's being used as an integer enum, but I think that's fine given I can't think of a single time we've used one of those.