### PR TITLE
Add PreferRequestYieldingResponsePattern cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -26,6 +26,12 @@ Bugcrowd/DangerousEnvMutation:
     - 'spec/spec_helper.rb'
   Enabled: true
 
+Bugcrowd/PreferRequestYieldingResponsePattern:
+  Description: 'Prefer request_yielding_response pattern for request specs'
+  Include:
+    - 'spec/requests/**/*.rb'
+  Enabled: true
+
 Bugcrowd/PreferSensibleStringEnum:
   Description: 'Prefer SensibleStringEnum over built in Rails enum'
   Enabled: true

--- a/lib/rubocop/cop/bugcrowd/prefer_request_yielding_response_pattern.rb
+++ b/lib/rubocop/cop/bugcrowd/prefer_request_yielding_response_pattern.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Bugcrowd
+      class PreferRequestYieldingResponsePattern < Cop
+        MSG = 'Prefer request_yielding_response pattern. See https://gist.github.com/maschwenk/6eaf0a3cbf0e6f1432b923cbca7e34d1'
+
+        def_node_matcher :begin_before_block?, <<~PATTERN
+          (block (send nil? :before) ...)
+        PATTERN
+
+        # using a search here to search the children of the before
+        def_node_search :calling_crud_method?, <<~PATTERN
+          (send nil? #crud_method? ...)
+        PATTERN
+
+        def crud_method?(meth)
+          %i[get put post patch delete].include? meth
+        end
+
+        def on_block(node)
+          if begin_before_block?(node) && calling_crud_method?(node)
+            add_offense(node)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/bugcrowd/prefer_request_yielding_response_pattern.rb
+++ b/lib/rubocop/cop/bugcrowd/prefer_request_yielding_response_pattern.rb
@@ -4,6 +4,52 @@ module RuboCop
   module Cop
     module Bugcrowd
       class PreferRequestYieldingResponsePattern < Cop
+        #
+        # @example
+        #
+        # # bad
+        # ```
+        # before { post user_path }
+        # it 'something happens' do
+        #   expect(response).to have_http_status :ok
+        # end
+        # ```
+        #
+        # # bad
+        # This pattern is not easily parseable, but is no better than
+        # the above pattern because it just gives the before a different name
+        # ```
+        # before { request }
+        # let(:request) { get user_path }
+        # it 'something happens' do
+        #   expect(response).to have_http_status :ok
+        # end
+        # ```
+        #
+        # # good
+        # Seperate the subject of the test from the test setup
+        # Use late binding to allow for more predictable behavior
+        # ```
+        #  subject(:request_yielding_response) do
+        #    http_request
+        #    response
+        #  end
+        #  let(:http_request) { get user_path(name: 'dilbert') }
+        #  it { is_expected.to be_ok }
+        #  it 'blah' do
+        #    expect { request_yielding_response }.to change(User, :count).by(1)
+        #  end
+        # ```
+        #
+        # # good
+        # Directly calling the request method is fine too!
+        # ```
+        #  it 'blah' do
+        #    get user_path(name: 'dilbert')
+        #  end
+        # ```
+        #
+
         MSG = 'Prefer request_yielding_response pattern. See https://gist.github.com/maschwenk/6eaf0a3cbf0e6f1432b923cbca7e34d1'
 
         def_node_matcher :begin_before_block?, <<~PATTERN

--- a/lib/rubocop/cop/bugcrowd_cops.rb
+++ b/lib/rubocop/cop/bugcrowd_cops.rb
@@ -4,6 +4,7 @@ require_relative 'bugcrowd/avoid_sample_in_specs'
 require_relative 'bugcrowd/current_jumping_controller_boundary'
 require_relative 'bugcrowd/dangerous_env_mutation'
 require_relative 'bugcrowd/faker'
+require_relative 'bugcrowd/prefer_request_yielding_response_pattern'
 require_relative 'bugcrowd/prefer_sensible_string_enum'
 require_relative 'bugcrowd/rails_configuration_mutation'
 

--- a/spec/rubocop/cop/bugcrowd/prefer_request_yielding_response_pattern_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/prefer_request_yielding_response_pattern_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Bugcrowd::PreferRequestYieldingResponsePattern do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense visit in single line block' do
+    expect_offense(<<~RUBY)
+      before { post user_path }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer request_yielding_response pattern. See https://gist.github.com/maschwenk/6eaf0a3cbf0e6f1432b923cbca7e34d1
+
+      it 'something happens' do
+        expect(response).to have_http_status :ok
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using multiline block' do
+    expect_offense(<<~RUBY)
+      before do
+      ^^^^^^^^^ Prefer request_yielding_response pattern. See https://gist.github.com/maschwenk/6eaf0a3cbf0e6f1432b923cbca7e34d1
+        post user_path
+        other_thing
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using multiline block regardless of order' do
+    expect_offense(<<~RUBY)
+      before do
+      ^^^^^^^^^ Prefer request_yielding_response pattern. See https://gist.github.com/maschwenk/6eaf0a3cbf0e6f1432b923cbca7e34d1
+        other_thing
+        post user_path
+      end
+    RUBY
+  end
+
+  it 'registers an offense when using other request methods' do
+    expect_offense(<<~RUBY)
+      before do
+      ^^^^^^^^^ Prefer request_yielding_response pattern. See https://gist.github.com/maschwenk/6eaf0a3cbf0e6f1432b923cbca7e34d1
+        other_thing
+        patch user_path
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using request_yielding_response pattern' do
+    expect_no_offenses(<<~RUBY)
+      subject(:request_yielding_response) do
+        http_request
+        response
+      end
+
+      let(:http_request) { get user_path(name: 'dilbert') }
+
+      it { is_expected.to be_ok }
+      it 'blah' do
+        expect { request_yielding_response }.to change(User, :count).by(1)
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Similar to #6

This cop codifies the strategies mentioned in https://gist.github.com/maschwenk/6eaf0a3cbf0e6f1432b923cbca7e34d1

This cop is less of a requirement and more of an agreed preference. This pattern has taken hold in Crowdcontrol so it'd be good to codify it, as the alternatives are predictably problematic. Note that the gist above mentions other valid strategies that can be used. This cop discourages putting the request in a `before` hook, but does not make requirements about what you do instead.