### PR TITLE
Update ddl check

### DIFF
--- a/lib/rubocop/cop/bugcrowd/add_index_non_concurrently.rb
+++ b/lib/rubocop/cop/bugcrowd/add_index_non_concurrently.rb
@@ -23,14 +23,9 @@ module RuboCop
               ' -- always add indexes concurrently, ' \
               'e.g. add_index :table_name, :column, algorithm: :concurrently'
 
-        def_node_matcher :add_index?, <<~PATTERN
-          (send nil? :add_index ...)
-        PATTERN
-
         def on_send(node)
           within_change_or_up_method?(node) &&
-            add_index?(node) &&
-            !add_index_concurrently?(node) &&
+            add_or_remove_index_without_concurrently?(node) &&
             add_offense(node)
         end
       end

--- a/lib/rubocop/cop/bugcrowd/database.rb
+++ b/lib/rubocop/cop/bugcrowd/database.rb
@@ -62,7 +62,7 @@ module RuboCop
           {:create_join_table :create_table :add_column :add_foreign_key :add_reference :add_timestamps :change_column :change_column_default :change_column_null :change_table :rename_column :rename_index :rename_table :drop_table :drop_join_table :remove_column :remove_columns :remove_foreign_key :remove_reference :remove_timestamps}
         PATTERN
 
-        def_node_matcher :ddl_statement?, <<~PATTERN
+        def_node_matcher :statement_requires_ddl_transaction?, <<~PATTERN
           (send nil? #requires_ddl_transaction_method? ...)
         PATTERN
 

--- a/lib/rubocop/cop/bugcrowd/database.rb
+++ b/lib/rubocop/cop/bugcrowd/database.rb
@@ -14,6 +14,11 @@ module RuboCop
           end
         end
 
+        def add_or_remove_index_without_concurrently?(node)
+          (add_index?(node) && !add_index_concurrently?(node)) ||
+            (remove_index?(node) && !remove_index_concurrently?(node))
+        end
+
         def_node_matcher :create_table?, <<-PATTERN
           (send nil? :create_table ...)
         PATTERN
@@ -29,6 +34,10 @@ module RuboCop
           )
         PATTERN
 
+        def_node_matcher :add_index?, <<~PATTERN
+          (send nil? :add_index ...)
+        PATTERN
+
         def_node_matcher :add_index_concurrently?, <<~PATTERN
           (send nil? :add_index _ _
             (hash
@@ -37,8 +46,20 @@ module RuboCop
           )
         PATTERN
 
+        def_node_matcher :remove_index?, <<~PATTERN
+          (send nil? :remove_index ...)
+        PATTERN
+
+        def_node_matcher :remove_index_concurrently?, <<~PATTERN
+          (send nil? :remove_index _ _
+            (hash
+              <(pair (sym :algorithm) (sym :concurrently)) ...>
+            )
+          )
+        PATTERN
+
         def_node_matcher :ddl_method?, <<~PATTERN
-          {:create_join_table :create_table :add_column :add_foreign_key :add_reference :add_timestamps :change_column :change_column_default :change_column_null :change_table :rename_column :rename_index :rename_table :drop_table :drop_join_table :remove_column :remove_columns :remove_foreign_key :remove_index :remove_index :remove_reference :remove_timestamps}
+          {:create_join_table :create_table :add_column :add_foreign_key :add_reference :add_timestamps :change_column :change_column_default :change_column_null :change_table :rename_column :rename_index :rename_table :drop_table :drop_join_table :remove_column :remove_columns :remove_foreign_key :remove_reference :remove_timestamps}
         PATTERN
 
         def_node_matcher :ddl_statement?, <<~PATTERN

--- a/lib/rubocop/cop/bugcrowd/database.rb
+++ b/lib/rubocop/cop/bugcrowd/database.rb
@@ -58,12 +58,12 @@ module RuboCop
           )
         PATTERN
 
-        def_node_matcher :ddl_method?, <<~PATTERN
+        def_node_matcher :requires_ddl_transaction_method?, <<~PATTERN
           {:create_join_table :create_table :add_column :add_foreign_key :add_reference :add_timestamps :change_column :change_column_default :change_column_null :change_table :rename_column :rename_index :rename_table :drop_table :drop_join_table :remove_column :remove_columns :remove_foreign_key :remove_reference :remove_timestamps}
         PATTERN
 
         def_node_matcher :ddl_statement?, <<~PATTERN
-          (send nil? #ddl_method? ...)
+          (send nil? #requires_ddl_transaction_method? ...)
         PATTERN
 
         def_node_search :with_disable_ddl_transaction_set?, <<~PATTERN

--- a/lib/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements.rb
+++ b/lib/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements.rb
@@ -24,19 +24,11 @@ module RuboCop
 
         MSG = 'Only disable ddl transactions for non-ddl statements'
 
-        def_node_matcher :add_index?, <<~PATTERN
-          (send nil? :add_index ...)
-        PATTERN
-
         def on_send(node)
           within_change_or_up_method?(node) &&
-            (ddl_statement?(node) || add_index_without_concurrently?(node)) &&
+            (ddl_statement?(node) || add_or_remove_index_without_concurrently?(node)) &&
             node.ancestors.any?(&method(:with_disable_ddl_transaction_set?)) &&
             add_offense(node)
-        end
-
-        def add_index_without_concurrently?(node)
-          add_index?(node) && !add_index_concurrently?(node)
         end
       end
     end

--- a/lib/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements.rb
+++ b/lib/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements.rb
@@ -26,7 +26,8 @@ module RuboCop
 
         def on_send(node)
           within_change_or_up_method?(node) &&
-            (ddl_statement?(node) || add_or_remove_index_without_concurrently?(node)) &&
+            (statement_requires_ddl_transaction?(node) ||
+              add_or_remove_index_without_concurrently?(node)) &&
             node.ancestors.any?(&method(:with_disable_ddl_transaction_set?)) &&
             add_offense(node)
         end

--- a/spec/rubocop/cop/bugcrowd/add_index_non_concurrently_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/add_index_non_concurrently_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Bugcrowd::AddIndexNonConcurrently do
+RSpec.describe RuboCop::Cop::Bugcrowd::AddIndexNonConcurrently do # rubocop:disable Metrics/BlockLength
   subject(:cop) { described_class.new(config) }
 
   let(:config) { RuboCop::Config.new }
@@ -39,6 +39,23 @@ RSpec.describe RuboCop::Cop::Bugcrowd::AddIndexNonConcurrently do
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ By default, Postgres locks writes to a table while creating an index on it  -- always add indexes concurrently, e.g. add_index :table_name, :column, algorithm: :concurrently
         add_index :table_name, :column_name, unique: true
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ By default, Postgres locks writes to a table while creating an index on it  -- always add indexes concurrently, e.g. add_index :table_name, :column, algorithm: :concurrently
+      end
+    RUBY
+  end
+
+  it do
+    expect_offense(<<~RUBY)
+      def up
+        remove_index :table_name, :column_name, unique: true
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ By default, Postgres locks writes to a table while creating an index on it  -- always add indexes concurrently, e.g. add_index :table_name, :column, algorithm: :concurrently
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when using concurrently' do
+    expect_no_offenses(<<~RUBY)
+      def change
+        remove_index :table_name, :column, algorithm: :concurrently
       end
     RUBY
   end

--- a/spec/rubocop/cop/bugcrowd/add_index_non_concurrently_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/add_index_non_concurrently_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Bugcrowd::AddIndexNonConcurrently do # rubocop:disable Metrics/BlockLength
+RSpec.describe RuboCop::Cop::Bugcrowd::AddIndexNonConcurrently do
   subject(:cop) { described_class.new(config) }
 
   let(:config) { RuboCop::Config.new }

--- a/spec/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/disable_ddl_only_with_non_ddl_statements_spec.rb
@@ -109,6 +109,18 @@ RSpec.describe RuboCop::Cop::Bugcrowd::DisableDdlOnlyWithNonDdlStatements do
     RUBY
   end
 
+  it 'does not register an offense when using the directive with a non-ddl command' do
+    expect_no_offenses(<<~RUBY)
+      class DerpMigration < ActiveRecord::Migration[5.2]
+        disable_ddl_transaction!
+
+        def change
+          remove_index :table_name, :column_name, unique: true, algorithm: :concurrently
+        end
+      end
+    RUBY
+  end
+
   it 'does not register an offense when not using the directive' do
     expect_no_offenses(<<~RUBY)
       class DerpMigration < ActiveRecord::Migration[5.2]


### PR DESCRIPTION
removing indexes in a reversible way requires the use of `algorithm: concurrently` among other attributes.  Concurrent indexes must disable ddl transaction so `remove_index` must be allowable as a non-ddl operation.