### PR TITLE
update sleepy suggestion to use wait_for_network_idle

### DIFF
--- a/lib/rubocop/cop/bugcrowd/sleepy_specs.rb
+++ b/lib/rubocop/cop/bugcrowd/sleepy_specs.rb
@@ -9,7 +9,7 @@ module RuboCop
       #   expect(page).to have_content('blah')
       #
       #   # good
-      #    page.driver.wait_for_network_idle
+      #   page.driver.wait_for_network_idle
       #   expect(page).to have_content('blah')
       #
       # https://github.com/rubycdp/cuprite#network-traffic

--- a/lib/rubocop/cop/bugcrowd/sleepy_specs.rb
+++ b/lib/rubocop/cop/bugcrowd/sleepy_specs.rb
@@ -9,29 +9,24 @@ module RuboCop
       #   expect(page).to have_content('blah')
       #
       #   # good
-      #   expect(page).to have_content('blah', wait: 3)
+      #    page.driver.wait_for_network_idle
+      #   expect(page).to have_content('blah')
       #
-      # https://github.com/teamcapybara/capybara#asynchronous-javascript-ajax-and-friends
-      # https://www.varvet.com/blog/why-wait_until-was-removed-from-capybara/
-      # https://www.reddit.com/r/rails/comments/25xrdy/is_there_a_way_to_change_capybaras_wait_time_just/
+      # https://github.com/rubycdp/cuprite#network-traffic
+      # https://github.com/rubycdp/ferrum#wait_for_idleoptions
       #
       #
-      # Other methods of avoiding sleep:
-      # 1. Use an intermediate matcher
-      # ```
-      # expect(page).to have_content(flash_mesage) # the fast action
-      # expect(page).to have_content(activity_message) # the slow action
-      # ```
-      # 2. Don't rely on something that is inherently slow
+      # Other method of avoiding sleep:
+      # 1. Don't rely on something that is inherently slow
       #   - instead of waiting for the page to be updated you can check
       #     that the correct behavior is called
       #     (this can sometimes make the test less robust)
       class SleepySpecs < RuboCop::Cop::Cop
         MSG = <<~COPCONTENT
-          🚨  Do not use sleep, use wait instead 🚨
+          🚨  Do not use sleep, use page.driver.wait_for_network_idle instead 🚨
           Sleep will wait for the given amount of time whether or not it needs to,
-          wait will only wait until the matcher is found.
-          https://semaphoreci.com/community/tutorials/5-tips-for-more-effective-capybara-tests
+          wait_for_network_idle Natively waits for network idle.
+          https://github.com/rubycdp/cuprite#network-traffic
         COPCONTENT
 
         def_node_matcher :sleeping?, <<-PATTERN

--- a/lib/rubocop/cop/bugcrowd/sleepy_specs.rb
+++ b/lib/rubocop/cop/bugcrowd/sleepy_specs.rb
@@ -8,16 +8,19 @@ module RuboCop
       #   sleep 1
       #   expect(page).to have_content('blah')
       #
-      #   # good – waiting network requests
+      #   # good
       #   page.driver.wait_for_network_idle
       #   expect(page).to have_content('blah')
       #
-      #   # also good – waiting for animations
+      #   # good
       #   expect(page).to have_content('blah', wait: 3)
+      #
+      # use wait_for_network_idle when waiting for network requests
       #
       # https://github.com/rubycdp/cuprite#network-traffic
       # https://github.com/rubycdp/ferrum#wait_for_idleoptions
       #
+      # use wait when waiting for frontend only animations
       # https://github.com/teamcapybara/capybara#asynchronous-javascript-ajax-and-friends
       # https://www.varvet.com/blog/why-wait_until-was-removed-from-capybara/
       # https://www.reddit.com/r/rails/comments/25xrdy/is_there_a_way_to_change_capybaras_wait_time_just/

--- a/lib/rubocop/cop/bugcrowd/sleepy_specs.rb
+++ b/lib/rubocop/cop/bugcrowd/sleepy_specs.rb
@@ -8,24 +8,32 @@ module RuboCop
       #   sleep 1
       #   expect(page).to have_content('blah')
       #
-      #   # good
+      #   # good – waiting network requests
       #   page.driver.wait_for_network_idle
       #   expect(page).to have_content('blah')
+      #
+      #   # also good – waiting for animations
+      #   expect(page).to have_content('blah', wait: 3)
       #
       # https://github.com/rubycdp/cuprite#network-traffic
       # https://github.com/rubycdp/ferrum#wait_for_idleoptions
       #
+      # https://github.com/teamcapybara/capybara#asynchronous-javascript-ajax-and-friends
+      # https://www.varvet.com/blog/why-wait_until-was-removed-from-capybara/
+      # https://www.reddit.com/r/rails/comments/25xrdy/is_there_a_way_to_change_capybaras_wait_time_just/
       #
       # Other method of avoiding sleep:
+      #
       # 1. Don't rely on something that is inherently slow
       #   - instead of waiting for the page to be updated you can check
       #     that the correct behavior is called
       #     (this can sometimes make the test less robust)
       class SleepySpecs < RuboCop::Cop::Cop
         MSG = <<~COPCONTENT
-          🚨  Do not use sleep, use page.driver.wait_for_network_idle instead 🚨
+          🚨  Do not use sleep, wait_for_network_idle or wait instead 🚨
           Sleep will wait for the given amount of time whether or not it needs to,
-          wait_for_network_idle Natively waits for network idle.
+          wait_for_network_idle natively waits for network idle,
+          wait will only wait until the matcher is found.
           https://github.com/rubycdp/cuprite#network-traffic
         COPCONTENT
 

--- a/spec/rubocop/cop/bugcrowd/sleepy_specs_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/sleepy_specs_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::Bugcrowd::SleepySpecs do
   xit 'registers an offense when using `#bad_method`' do
     expect_offense(<<~RUBY)
       sleep(1)
-      ^^^^^^^^ 🚨  Do not use sleep, use page.driver.wait_for_network_idle instead 🚨
+      ^^^^^^^^ 🚨  Do not use sleep, wait_for_network_idle or wait instead 🚨
     RUBY
   end
 

--- a/spec/rubocop/cop/bugcrowd/sleepy_specs_spec.rb
+++ b/spec/rubocop/cop/bugcrowd/sleepy_specs_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::Bugcrowd::SleepySpecs do
   xit 'registers an offense when using `#bad_method`' do
     expect_offense(<<~RUBY)
       sleep(1)
-      ^^^^^^^^ 🚨  Do not use sleep, use wait instead 🚨
+      ^^^^^^^^ 🚨  Do not use sleep, use page.driver.wait_for_network_idle instead 🚨
     RUBY
   end
 


### PR DESCRIPTION
update the cop to suggest `wait_for_network_idle` instead of `wait` when waiting for network 

https://github.com/rubycdp/cuprite#network-traffic
https://github.com/rubycdp/ferrum#wait_for_idleoptions